### PR TITLE
Fixing readme as cron.py is wrong and example crontab was showing eve…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ ComponentId = 1
 
 ### Usage
 
-Register a cron that runs `cron.py` every 5 minutes.
+Register a cron that runs `update_status.py` every 5 minutes.
 
 ```bash
 # Open cron file to edit.
@@ -39,10 +39,10 @@ crontab -e
 
 Edit the crontab file and add this line:
 ```bash
-*/1 * * * * python3 ~/path/update_status.py ~/path/config.ini
+*/5 * * * * python3 ~/path/update_status.py ~/path/config.ini
 ```
 
-_Note that the path of cron.py may vary depending on the location you cloned the repository_
+_Note that the path of the update_status.py & config.ini files may vary depending on the location you cloned the repository_
 
 ### Running manually
 


### PR DESCRIPTION
…ry 1 minute
- Fixed crontab to show an example of every 5 minutes to match the text saying it runs every 5 minutes (previously was showing every 1).
- Removed references to cron.py as that's not actually a file, the crontab is setup to run update_status.py, not cron.py.
