### PR TITLE
Support for Uptime Robot APIv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ComponentId = 1
 ```
 
 * `CachetApiKey`:  Cachet API key.
+* `https://url.in.uptime.robot.com`: This exact "monitor" url set in UptimeRobot (eg. http://mywebsite.com) 
 * `CachetUrl`: URL of the API of the status page you want to show the site availability in.
 * `MetricId`: Id of the Cachet metric with site availability.
 * `ComponentId`: (Optional) Id of the component you want to update on each check.


### PR DESCRIPTION
According to `https://uptimerobot.com/apiv1` 
> Important: The APIv1 will be retired by 1 Jan 2017 and please switch to APIv2 before that date.

As it's well passed 1 Jan 2017, they could kill off APIv1 support any day so I've hacked this together and it's working with their APIv2.  I'm no Python guy so feel free to tidy anything up.