### PR TITLE
Major upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+config.ini

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Cachet is an open source status page system, this repository is a Python script that does two things, **first**, it reads the status of a page in UptimeRobot and updates a cachet component based on that status and **second**, it updates a metric with the historic uptime ratio from Uptime Robot.
 
-**Component status: Uptime Robot (left), Cachet (right)**
-
-* Not checked yet: Operational
-* Up: Operational
-* Seems down: Partial outage
-* Down: Major outage
+**Component status**
+|Uptime Robot|Cachet|
+|Not checked yet|Operational|
+|Up|Operational|
+|Seems down|Partial outage|
+|Down|Major outage|
 
 ### Getting started 
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,28 @@ Cachet is an open source status page system, this repository is a Python script 
 
 To get started, you have to specify your Cachet and UptimeRobot settings and in **config.ini**.
 ```ini
-[uptimeRobot]
+[uptimeRobot] // Global uptimerobot API
 UptimeRobotMainApiKey = your-api-key
 
-[https://url.in.uptime.robot.com]
+[cachet] // Global cachet status API
+CachetApiKey = cachet-api-key
+CachetUrl = https://status.mycompany.com
+
+[uptimeRobotMetricID] // This will update ComponentId 1 on the global Cachet
+ComponentId = 1
+
+[uptimeRobotMetricID] // Still possible to use custom cachet settings 
 CachetApiKey = cachet-api-key
 CachetUrl = https://status.mycompany.com
 MetricId = 1
 ComponentId = 1
 ```
 
+* `UptimeRobotMainApiKey`: UptimeRobot API key.
+* `uptimeRobotMetricID`: This exact "monitor" id set in UptimeRobot. You can find the id's by running `python update_status.py config.ini getIds`
 * `CachetApiKey`:  Cachet API key.
-* `https://url.in.uptime.robot.com`: This exact "monitor" url set in UptimeRobot (eg. http://mywebsite.com) 
 * `CachetUrl`: URL of the API of the status page you want to show the site availability in.
-* `MetricId`: Id of the Cachet metric with site availability.
+* `MetricId`: (Optional) Id of the Cachet metric with site availability.
 * `ComponentId`: (Optional) Id of the component you want to update on each check.
 
 ### Usage
@@ -40,7 +48,7 @@ crontab -e
 
 Edit the crontab file and add this line:
 ```bash
-*/5 * * * * python3 ~/path/update_status.py ~/path/config.ini
+*/5 * * * * python ~/path/update_status.py ~/path/config.ini
 ```
 
 _Note that the path of the update_status.py & config.ini files may vary depending on the location you cloned the repository_
@@ -50,7 +58,7 @@ _Note that the path of the update_status.py & config.ini files may vary dependin
 You can also update your Cachet data manually by running this:
 
 ```python
-python3 update_status.py config.ini
+python update_status.py config.ini
 
 >>> Updating monitor MySite. URL: http://mysite.co. ID: 12345678
 >>> Metric created: {'data': {'calculated_value': 99.99, 'counter': 1, 'metric_id': 4, 'value': 99.99, 'created_at': '2016-08-12 08:23:10', 'updated_at': '2016-08-12 08:23:10', 'id': 99}}

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ UptimeRobotMainApiKey = your-api-key
 CachetApiKey = cachet-api-key
 CachetUrl = https://status.mycompany.com
 
-[uptimeRobotMetricID] // This will update ComponentId 1 on the global Cachet
+[uptimeRobotMonitorID1] // This will update ComponentId 1 on the global Cachet
 ComponentId = 1
 
-[uptimeRobotMetricID] // Still possible to use custom cachet settings 
+[uptimeRobotMonitorID2] // Still possible to use custom cachet settings 
 CachetApiKey = cachet-api-key
 CachetUrl = https://status.mycompany.com
 MetricId = 1
@@ -36,6 +36,10 @@ ComponentId = 1
 * `CachetUrl`: URL of the API of the status page you want to show the site availability in.
 * `MetricId`: (Optional) Id of the Cachet metric with site availability.
 * `ComponentId`: (Optional) Id of the component you want to update on each check.
+
+Either `MetricId` or `ComponentId` must be defined per `uptimeRobotMonitorID`
+
+MetricId is special, it will try to sync the graph from UptimeRobot to Cachet. Please keep this in mind at all times.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Cachet is an open source status page system, this repository is a Python script that does two things, **first**, it reads the status of a page in UptimeRobot and updates a cachet component based on that status and **second**, it updates a metric with the historic uptime ratio from Uptime Robot.
 
-**Component status**
+### Component status
 
 | Uptime Robot | Cachet |
 | --- | --- |
@@ -33,7 +33,7 @@ ComponentId = 1
 ```
 
 * `UptimeRobotMainApiKey`: UptimeRobot API key.
-* `uptimeRobotMetricID`: This exact "monitor" id set in UptimeRobot. You can find the id's by running `python update_status.py config.ini getIds`
+* `uptimeRobotMonitorID`: This exact "monitor" id set in UptimeRobot. You can find the id's by running `python update_status.py config.ini printIds`
 * `CachetApiKey`:  Cachet API key.
 * `CachetUrl`: URL of the API of the status page you want to show the site availability in.
 * `MetricId`: (Optional) Id of the Cachet metric with site availability.
@@ -43,10 +43,15 @@ Either `MetricId` or `ComponentId` must be defined per `uptimeRobotMonitorID`
 
 MetricId is special, it will try to sync the graph from UptimeRobot to Cachet. Please keep this in mind at all times.
 
+### Command and args
+`update_status.py <config> [--printIds]`  
+`config` is mandantory and must point to the path where a config file can be found.  
+`--printIds` will print a list with all monitors in UptimeRobot with there name and ID. This ID needed in the config.ini file.
+
+You can always do `update_status.py -h` for more info.
+
 ### Usage
-
 Register a cron that runs `update_status.py` every 5 minutes.
-
 ```bash
 # Open cron file to edit.
 crontab -e

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ crontab -e
 
 Edit the crontab file and add this line:
 ```bash
+*/5 * * * * ~/path/run.sh
+```
+
+or if you have you're config in a other location:
+```bash
 */5 * * * * python ~/path/update_status.py ~/path/config.ini
 ```
 
@@ -69,8 +74,12 @@ _Note that the path of the update_status.py & config.ini files may vary dependin
 You can also update your Cachet data manually by running this:
 
 ```python
-python update_status.py config.ini
+python update_status.py
 
->>> Updating monitor MySite. URL: http://mysite.co. ID: 12345678
->>> Metric created: {'data': {'calculated_value': 99.99, 'counter': 1, 'metric_id': 4, 'value': 99.99, 'created_at': '2016-08-12 08:23:10', 'updated_at': '2016-08-12 08:23:10', 'id': 99}}
+INFO:cachet-uptime-robot:Updating monitor MySite. URL: http://mysite.co. ID: 12345678
+INFO:cachet-uptime-robot:HTTP GET URL: https://status.mycompany.com/api/v1/components/1
+INFO:cachet-uptime-robot:No status change on component 1. Skipping update.
+INFO:cachet-uptime-robot:Updating monitor MySite Mail. URL: http://mail.mysite.co. ID: 12345687
+INFO:cachet-uptime-robot:HTTP GET URL: https://status.mycompany.com/api/v1/components/2
+INFO:cachet-uptime-robot:Updating component 2 status: 1 -> 4
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 Cachet is an open source status page system, this repository is a Python script that does two things, **first**, it reads the status of a page in UptimeRobot and updates a cachet component based on that status and **second**, it updates a metric with the historic uptime ratio from Uptime Robot.
 
 **Component status**
-|Uptime Robot|Cachet|
-|Not checked yet|Operational|
-|Up|Operational|
-|Seems down|Partial outage|
-|Down|Major outage|
+
+| Uptime Robot | Cachet |
+| --- | --- |
+| Not checked yet | Operational |
+| Up | Operational |
+| Seems down | Partial outage |
+| Down | Major outage |
 
 ### Getting started 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ComponentId = 1
 ```
 
 * `UptimeRobotMainApiKey`: UptimeRobot API key.
-* `uptimeRobotMonitorID`: This exact "monitor" id set in UptimeRobot. You can find the id's by running `python update_status.py config.ini printIds`
+* `uptimeRobotMonitorID`: This exact "monitor" id set in UptimeRobot. You can find the id's by running `python update_status.py config.ini --printIds`
 * `CachetApiKey`:  Cachet API key.
 * `CachetUrl`: URL of the API of the status page you want to show the site availability in.
 * `MetricId`: (Optional) Id of the Cachet metric with site availability.

--- a/config.ini
+++ b/config.ini
@@ -1,8 +1,0 @@
-[uptimeRobot]
-UptimeRobotMainApiKey = abcd
-
-[https://url.in.uptime.robot.com]
-CachetApiKey = cachet-api-key
-CachetUrl = https://status.mycompany.com
-MetricId = 1
-ComponentId = 1

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,22 @@
+[uptimeRobot]
+UptimeRobotMainApiKey = your-api-key
+
+[cachet]
+CachetApiKey = cachet-api-key
+CachetUrl = https://status.mycompany.com
+
+[uptimeRobotMetricID1]
+ComponentId = 1
+
+[uptimeRobotMetricID2]
+CachetApiKey = cachet-api-key
+CachetUrl = https://status.mycompany.com
+MetricId = 1
+ComponentId = 2
+
+[uptimeRobotMetricID3]
+MetricId = 2
+ComponentId = 3
+
+[uptimeRobotMetricID4]
+MetricId = 3

--- a/config.ini.example
+++ b/config.ini.example
@@ -5,18 +5,18 @@ UptimeRobotMainApiKey = your-api-key
 CachetApiKey = cachet-api-key
 CachetUrl = https://status.mycompany.com
 
-[uptimeRobotMetricID1]
+[uptimeRobotMonitorID1]
 ComponentId = 1
 
-[uptimeRobotMetricID2]
+[uptimeRobotMonitorID2]
 CachetApiKey = cachet-api-key
-CachetUrl = https://status.mycompany.com
+CachetUrl = https://status2.mycompany.com
 MetricId = 1
 ComponentId = 2
 
-[uptimeRobotMetricID3]
+[uptimeRobotMonitorID3]
 MetricId = 2
 ComponentId = 3
 
-[uptimeRobotMetricID4]
+[uptimeRobotMonitorID4]
 MetricId = 3

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Detect absolute and full path
+cd "$(dirname $0)"
+DIR=$(pwd)
+cd - > /dev/null
+
+# Run python
 python "$DIR/update_status.py" "$DIR/config.ini"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+python "$DIR/update_status.py" "$DIR/config.ini"

--- a/tests/test_update_status.py
+++ b/tests/test_update_status.py
@@ -1,0 +1,60 @@
+import unittest.mock as mock
+import pytest
+import update_status
+
+
+class TestMonitor(object):
+    def test_send_data_to_cachet_updates_the_component_status(self, monitor, uptimerobot_monitor):
+        website_config = monitor.monitor_list[uptimerobot_monitor['url']]
+
+        with mock.patch('update_status.CachetHq') as cachet:
+            monitor.send_data_to_cachet(uptimerobot_monitor)
+
+        cachet().update_component.assert_called_with(
+            website_config['component_id'],
+            int(uptimerobot_monitor['status'])
+        )
+
+    def test_send_data_to_cachet_updates_data_metrics(self, monitor, uptimerobot_monitor):
+        website_config = monitor.monitor_list[uptimerobot_monitor['url']]
+
+        with mock.patch('update_status.CachetHq') as cachet:
+            monitor.send_data_to_cachet(uptimerobot_monitor)
+
+        cachet().set_data_metrics.assert_called_with(
+            uptimerobot_monitor['custom_uptime_ratio'],
+            mock.ANY,
+            website_config['metric_id']
+        )
+
+
+@pytest.fixture
+def monitor_list():
+    return {
+        'http://example.org': {
+            'cachet_api_key': 'CACHET_API_KEY',
+            'cachet_url': 'http://status.example.org',
+            'metric_id': '1',
+            'component_id': '1',
+        },
+    }
+
+
+@pytest.fixture
+def uptimerobot_monitor(monitor_list):
+    monitors_urls = [m for m in monitor_list.keys()]
+    url = monitors_urls[0]
+
+    return {
+        'url': url,
+        'friendly_name': url,
+        'id': 'monitor_id',
+        'status': '2',  # UP,
+        'custom_uptime_ratio': '100',
+    }
+
+
+@pytest.fixture
+def monitor(monitor_list):
+    api_key = 'UPTIME_ROBOT_API_KEY'
+    return update_status.Monitor(monitor_list, api_key)

--- a/tests/test_update_status.py
+++ b/tests/test_update_status.py
@@ -5,7 +5,7 @@ import update_status
 
 class TestMonitor(object):
     def test_send_data_to_cachet_updates_the_component_status(self, monitor, uptimerobot_monitor):
-        website_config = monitor.monitor_list[uptimerobot_monitor['url']]
+        website_config = monitor.monitor_list[uptimerobot_monitor['id']]
 
         with mock.patch('update_status.CachetHq') as cachet:
             monitor.sync_metric = lambda x, y: None
@@ -18,7 +18,7 @@ class TestMonitor(object):
 
     @pytest.mark.skip
     def test_send_data_to_cachet_updates_data_metrics(self, monitor, uptimerobot_monitor):
-        website_config = monitor.monitor_list[uptimerobot_monitor['url']]
+        website_config = monitor.monitor_list[uptimerobot_monitor['id']]
 
         with mock.patch('update_status.CachetHq') as cachet:
             monitor.sync_metric = lambda x, y: None
@@ -60,11 +60,10 @@ class TestMonitor(object):
             )
 
 
-
 @pytest.fixture
 def monitor_list():
     return {
-        'http://example.org': {
+        '6516846': {
             'cachet_api_key': 'CACHET_API_KEY',
             'cachet_url': 'http://status.example.org',
             'metric_id': '1',
@@ -88,13 +87,13 @@ def cachet_metric():
 
 @pytest.fixture
 def uptimerobot_monitor(monitor_list):
-    monitors_urls = [m for m in monitor_list.keys()]
-    url = monitors_urls[0]
+    monitors_ids = [m for m in monitor_list.keys()]
+    id = monitors_ids[0]
 
     return {
-        'url': url,
-        'friendly_name': url,
-        'id': 'monitor_id',
+        'url': 'monitor_url',
+        'friendly_name': 'friendly_name',
+        'id': id,
         'status': '2',  # UP,
         'custom_uptime_ratio': '100',
         'response_times': [
@@ -113,10 +112,10 @@ def monitor(monitor_list):
     api_key = 'UPTIME_ROBOT_API_KEY'
     return update_status.Monitor(monitor_list, api_key)
 
+
 @pytest.fixture
 def cachet():
     return update_status.CachetHq(
         cachet_api_key='CACHET_API_KEY',
         cachet_url='CACHET_URL'
     )
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist =
+  py36
+  lint
+skipsdist = True
+
+[testenv]
+deps =
+  pytest
+setenv =
+  PYTHONPATH = {toxinidir}
+commands =
+  py.test {posargs}
+
+[testenv:lint]
+deps =
+  pylama
+commands =
+  pylama {toxinidir}/update_status.py
+
+[pytest]
+testpaths = tests
+
+[pylama]
+ignore = E501

--- a/update_status.py
+++ b/update_status.py
@@ -9,7 +9,7 @@ from urllib import parse
 from datetime import datetime, timezone
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('cachet-uptime-robot')
 
 CACHETHQ_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 USER_AGENT = 'CachetUptimeRobotIntegration'

--- a/update_status.py
+++ b/update_status.py
@@ -27,20 +27,20 @@ class UptimeRobot(object):
         """
         endpoint = self.base_url
         data = parse.urlencode({
-                'api_key': format(self.api_key),
-                'format': 'json',
-                # responseTimes - optional (defines if the response time data of each
-                # monitor will be returned. Should be set to 1 for getting them.
-                # Default is 0)
-                'response_times': format(response_times),
-                # logs - optional (defines if the logs of each monitor will be
-                # returned. Should be set to 1 for getting the logs. Default is 0)
-                'logs': format(logs),
-                # customUptimeRatio - optional (defines the number of days to calculate
-                # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
-                # uptime ratios for those periods)
-                'custom_uptime_ratios': format(uptime_ratio)
-            }).encode('utf-8')
+            'api_key': format(self.api_key),
+            'format': 'json',
+            # responseTimes - optional (defines if the response time data of each
+            # monitor will be returned. Should be set to 1 for getting them.
+            # Default is 0)
+            'response_times': format(response_times),
+            # logs - optional (defines if the logs of each monitor will be
+            # returned. Should be set to 1 for getting the logs. Default is 0)
+            'logs': format(logs),
+            # customUptimeRatio - optional (defines the number of days to calculate
+            # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
+            # uptime ratios for those periods)
+            'custom_uptime_ratios': format(uptime_ratio)
+        }).encode('utf-8')
 
         url = request.Request(
             url=endpoint,

--- a/update_status.py
+++ b/update_status.py
@@ -284,13 +284,13 @@ class Monitor(object):
     def _log_unknown_monitors(self, monitors):
         configured_monitors = set(self.monitor_list.keys())
         uptimerobot_monitors = set([
-            monitor['url'] for monitor in monitors
+            monitor['id'] for monitor in monitors
         ])
 
         unknown_monitors = configured_monitors - uptimerobot_monitors
 
         if unknown_monitors:
-            logger.warn(
+            logger.warning(
                 'The following monitors do not exist in UptimeRobot: %s',
                 unknown_monitors
             )

--- a/update_status.py
+++ b/update_status.py
@@ -200,7 +200,7 @@ class Monitor(object):
             )
 
         if 'metric_id' in website_config:
-            self.sync_metric(monitor, cachet)
+            self.sync_metric(monitor, self.cachet)
 
     def sync_metric(self, monitor, cachet):
         website_config = self._get_website_config(monitor)

--- a/update_status.py
+++ b/update_status.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-import json
-import sys
+import argparse
 import configparser
+import json
 import logging
+import sys
 from urllib import request
 from urllib import parse
 from datetime import datetime, timezone
@@ -246,7 +247,7 @@ class Monitor(object):
 
     def _get_website_config(self, monitor):
         try:
-            return self.monitor_list[monitor.get('url')]
+            return self.monitor_list[monitor.get('id')]
         except KeyError:
             logger.error('Monitor is not valid')
             sys.exit(1)
@@ -259,54 +260,80 @@ class Monitor(object):
         return int(unixtime)
 
 
-if __name__ == "__main__":
-    CONFIG = configparser.ConfigParser()
-    CONFIG.read(sys.argv[1])
-    SECTIONS = CONFIG.sections()
+def main():
+    args = parse_args()
+    monitor_dict, uptime_robot_api_key, cachet = parse_config(args.config_file)
 
-    if not SECTIONS:
+    if args.print_ids:
+        uptime_robot = UptimeRobot(uptime_robot_api_key)
+        success, response = uptime_robot.get_monitors(response_times=1)
+        if success:
+            monitors = response.get('monitors')
+            for monitor in monitors:
+                print('Monitor ID: {1}, Name: {0}.'.format(
+                    monitor['friendly_name'],
+                    monitor['id'],
+                ))
+        else:
+            print('ERROR: No data was returned from UptimeMonitor')
+        sys.exit(1)
+
+    Monitor(monitor_list=monitor_dict, api_key=uptime_robot_api_key, cachet=cachet).update()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Send data from UptimeRobot to CachetHQ')
+
+    parser.add_argument(
+        'config_file',
+        nargs='?',
+        type=argparse.FileType('r'),
+        help='path to the configuration file (default: config.ini in current folder)',
+        default='config.ini',
+        required=True
+    )
+
+    parser.add_argument(
+        'printIds',
+        action='store_true',
+        help='get UptimeRobot api key from config and print list met monitors from UptimeRobot',
+        dest='print_ids'
+    )
+
+    return parser.parse_args()
+
+
+def parse_config(config_file):
+    config = configparser.ConfigParser()
+    config.read_file(config_file)
+
+    if not config.sections():
         logger.error('File path is not valid')
         sys.exit(1)
 
-    if sys.argv[2] == 'getIds':
-        for element in SECTIONS:
-            if element == 'uptimeRobot':
-                uptime_robot = UptimeRobot(CONFIG[element]['UptimeRobotMainApiKey'])
-                success, response = uptime_robot.get_monitors(response_times=1)
-                if success:
-                    monitors = response.get('monitors')
-                    for monitor in monitors:
-                        print('Monitor ID: {1}, Name: {0}.'.format(
-                            monitor['friendly_name'],
-                            monitor['id'],
-                        ))
-                else:
-                    print('ERROR: No data was returned from UptimeMonitor')
-        sys.exit(1)
-
-    UPTIME_ROBOT_API_KEY = None
-    MONITOR_DICT = {}
-    for element in SECTIONS:
+    uptime_robot_api_key = None
+    monitor_dict = {}
+    for element in config.sections():
         if element == 'uptimeRobot':
-            uptime_robot_api_key = CONFIG[element]['UptimeRobotMainApiKey']
+            uptime_robot_api_key = config[element]['UptimeRobotMainApiKey']
         elif element == 'cachet':
-            cachet_api_key = CONFIG[element]['CachetApiKey']
-            cachet_url = CONFIG[element]['CachetUrl']
+            cachet_api_key = config[element]['CachetApiKey']
+            cachet_url = config[element]['CachetUrl']
         else:
-            elementInt = int(element)
-            MONITOR_DICT[elementInt] = {}
-            if 'CachetApiKey' in CONFIG[element] and 'CachetUrl' in CONFIG[element]:
-                MONITOR_DICT[elementInt].update({
-                    'cachet_api_key': CONFIG[element]['CachetApiKey'],
-                    'cachet_url': CONFIG[element]['CachetUrl'],
+            element_int = int(element)
+            monitor_dict[element_int] = {}
+            if 'CachetApiKey' in config[element] and 'CachetUrl' in config[element]:
+                monitor_dict[element_int].update({
+                    'cachet_api_key': config[element]['CachetApiKey'],
+                    'cachet_url': config[element]['CachetUrl'],
                 })
-            if 'MetricId' in CONFIG[element]:
-                MONITOR_DICT[elementInt].update({
-                    'metric_id': CONFIG[element]['MetricId'],
+            if 'MetricId' in config[element]:
+                monitor_dict[element_int].update({
+                    'component_id': config[element]['MetricId'],
                 })
-            if 'ComponentId' in CONFIG[element]:
-                MONITOR_DICT[elementInt].update({
-                    'component_id': CONFIG[element]['ComponentId'],
+            if 'ComponentId' in config[element]:
+                monitor_dict[element_int].update({
+                    'metric_id': config[element]['ComponentId'],
                 })
 
     cachet = CachetHq(
@@ -314,5 +341,8 @@ if __name__ == "__main__":
         cachet_url=cachet_url,
     )
 
-    MONITOR = Monitor(monitor_list=MONITOR_DICT, api_key=uptime_robot_api_key, cachet=cachet)
-    MONITOR.update()
+    return monitor_dict, uptime_robot_api_key, cachet
+
+
+if __name__ == "__main__":
+    main()

--- a/update_status.py
+++ b/update_status.py
@@ -339,14 +339,14 @@ def parse_args():
         nargs='?',
         type=argparse.FileType('r'),
         help='path to the configuration file (default: config.ini in current folder)',
-        default='config.ini',
-        required=True
+        default='config.ini'
     )
 
     parser.add_argument(
-        'printIds',
+        '--printIds',
+        '-p',
         action='store_true',
-        help='get UptimeRobot api key from config and print list met monitors from UptimeRobot',
+        help='print list with monitors from UptimeRobot',
         dest='print_ids'
     )
 

--- a/update_status.py
+++ b/update_status.py
@@ -158,6 +158,8 @@ class CachetHq(object):
         return data
 
     def _request(self, method, url, data=None):
+        logger.info('HTTP %s URL: %s', method, url)
+
         if data:
             data = parse.urlencode(data).encode('utf-8')
 
@@ -244,7 +246,13 @@ class Monitor(object):
                         monitor['url'],
                         monitor['id']
                     )
-                    self.send_data_to_cachet(monitor)
+                    try:
+                        self.send_data_to_cachet(monitor)
+                    except:
+                        logging.exception(
+                            'Exception raised when updating monitor %s',
+                            monitor['friendly_name']
+                        )
         else:
             logger.error('No data was returned from UptimeMonitor')
 

--- a/update_status.py
+++ b/update_status.py
@@ -192,17 +192,18 @@ class Monitor(object):
         )
 
         if 'component_id' in website_config:
-            cachet.update_component(
+            self.cachet.update_component(
                 website_config['component_id'],
                 int(monitor.get('status'))
             )
 
-        metric = cachet.set_data_metrics(
-            monitor.get('custom_uptime_ratio'),
-            int(time.time()),
-            website_config['metric_id']
-        )
-        print('Metric created: {0}'.format(metric))
+        if 'metric_id' in website_config:
+            metric = self.cachet.set_data_metrics(
+                monitor.get('custom_uptime_ratio'),
+                int(time.time()),
+                website_config['metric_id']
+            )
+            print('Metric created: {0}'.format(metric))
 
     def update(self):
         """ Update all monitors uptime and status.

--- a/update_status.py
+++ b/update_status.py
@@ -248,7 +248,7 @@ class Monitor(object):
                     )
                     try:
                         self.send_data_to_cachet(monitor)
-                    except:
+                    except Exception:
                         logging.exception(
                             'Exception raised when updating monitor %s',
                             monitor['friendly_name']

--- a/update_status.py
+++ b/update_status.py
@@ -262,6 +262,7 @@ class Monitor(object):
         success, response = uptime_robot.get_monitors(response_times=1)
         if success:
             monitors = response.get('monitors')
+            self._log_unknown_monitors(monitors)
             for monitor in monitors:
                 if monitor['id'] in self.monitor_list:
                     logger.info(
@@ -279,6 +280,20 @@ class Monitor(object):
                         )
         else:
             logger.error('No data was returned from UptimeMonitor')
+
+    def _log_unknown_monitors(self, monitors):
+        configured_monitors = set(self.monitor_list.keys())
+        uptimerobot_monitors = set([
+            monitor['url'] for monitor in monitors
+        ])
+
+        unknown_monitors = configured_monitors - uptimerobot_monitors
+
+        if unknown_monitors:
+            logger.warn(
+                'The following monitors do not exist in UptimeRobot: %s',
+                unknown_monitors
+            )
 
     def _get_website_config(self, monitor):
         try:

--- a/update_status.py
+++ b/update_status.py
@@ -182,7 +182,7 @@ class Monitor(object):
             Data sent is the value of last `Uptime`.
         """
         try:
-            website_config = self.monitor_list[monitor.get('url')]
+            website_config = self.monitor_list[monitor.get('id')]
         except KeyError:
             print('ERROR: monitor is not valid')
             sys.exit(1)
@@ -215,7 +215,7 @@ class Monitor(object):
         if success:
             monitors = response.get('monitors')
             for monitor in monitors:
-                if monitor['url'] in self.monitor_list:
+                if monitor['id'] in self.monitor_list:
                     print('Updating monitor {0}. URL: {1}. ID: {2}'.format(
                         monitor['friendly_name'],
                         monitor['url'],
@@ -233,6 +233,22 @@ if __name__ == "__main__":
 
     if not SECTIONS:
         print('ERROR: File path is not valid')
+        sys.exit(1)
+
+    if sys.argv[2] == 'getIds':
+        for element in SECTIONS:
+            if element == 'uptimeRobot':
+                uptime_robot = UptimeRobot(CONFIG[element]['UptimeRobotMainApiKey'])
+                success, response = uptime_robot.get_monitors(response_times=1)
+                if success:
+                    monitors = response.get('monitors')
+                    for monitor in monitors:
+                        print('Monitor ID: {1}, Name: {0}.'.format(
+                            monitor['friendly_name'],
+                            monitor['id'],
+                        ))
+                else:
+                    print('ERROR: No data was returned from UptimeMonitor')
         sys.exit(1)
 
     UPTIME_ROBOT_API_KEY = None

--- a/update_status.py
+++ b/update_status.py
@@ -100,7 +100,7 @@ class CachetHq(object):
 
         if component_status:
             component = self.get_component(id_component)
-            current_component_status = component.get('data', {}).get('status')
+            current_component_status = int(component.get('data', {}).get('status'))
             if current_component_status == component_status:
                 # FIXME: This is only necessary for CachetHQ <=2.3. Whenever we
                 # migrate to 2.4, we can remove this check.

--- a/update_status.py
+++ b/update_status.py
@@ -21,26 +21,29 @@ class UptimeRobot(object):
         """
         endpoint = self.base_url
         data = parse.urlencode({
-                'api_key': format(self.api_key),
-                'format': 'json',
-                # responseTimes - optional (defines if the response time data of each
-                # monitor will be returned. Should be set to 1 for getting them.
-                # Default is 0)
-                'response_times': format(response_times),
-                 # logs - optional (defines if the logs of each monitor will be
-                # returned. Should be set to 1 for getting the logs. Default is 0)
-                'logs': format(logs),
-                # customUptimeRatio - optional (defines the number of days to calculate
-                # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
-                # uptime ratios for those periods)
-                'custom_uptime_ratios': format(uptime_ratio)
-            }).encode('utf-8')
+            'api_key': format(self.api_key),
+            'format': 'json',
+            # responseTimes - optional (defines if the response time data of each
+            # monitor will be returned. Should be set to 1 for getting them.
+            # Default is 0)
+            'response_times': format(response_times),
+            # logs - optional (defines if the logs of each monitor will be
+            # returned. Should be set to 1 for getting the logs. Default is 0)
+            'logs': format(logs),
+            # customUptimeRatio - optional (defines the number of days to calculate
+            # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
+            # uptime ratios for those periods)
+            'custom_uptime_ratios': format(uptime_ratio)
+        }).encode('utf-8')
 
         url = request.Request(
             url=endpoint,
             data=data,
             method='POST',
-            headers={'content-type': "application/x-www-form-urlencoded",'cache-control': "no-cache"},
+            headers={
+                'Content-Type': 'application/x-www-form-urlencoded ',
+                'Cache-Control': 'no-cache'
+            },
         )
 
         # Verifying in the response is jsonp in otherwise is error

--- a/update_status.py
+++ b/update_status.py
@@ -177,7 +177,7 @@ class Monitor(object):
         self.api_key = api_key
         self.cachet = cachet
 
-    def send_data_to_catchet(self, monitor):
+    def send_data_to_cachet(self, monitor):
         """ Posts data to Cachet API.
             Data sent is the value of last `Uptime`.
         """
@@ -221,7 +221,7 @@ class Monitor(object):
                         monitor['url'],
                         monitor['id'],
                     ))
-                    self.send_data_to_catchet(monitor)
+                    self.send_data_to_cachet(monitor)
         else:
             print('ERROR: No data was returned from UptimeMonitor')
 

--- a/update_status.py
+++ b/update_status.py
@@ -12,6 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 CACHETHQ_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+USER_AGENT = 'CachetUptimeRobotIntegration'
 
 
 class UptimeRobot(object):
@@ -48,7 +49,7 @@ class UptimeRobot(object):
             method='POST',
             headers={
                 'Content-Type': 'application/x-www-form-urlencoded ',
-                'Cache-Control': 'no-cache'
+                'Cache-Control': 'no-cache',
             },
         )
 
@@ -167,8 +168,10 @@ class CachetHq(object):
             headers={
                 'X-Cachet-Token': self.cachet_api_key,
                 'Time-Zone': 'Etc/UTC',
+                'User-Agent': USER_AGENT,
             },
         )
+
         response = request.urlopen(req)
         content = response.read().decode('utf-8')
 

--- a/update_status.py
+++ b/update_status.py
@@ -27,20 +27,20 @@ class UptimeRobot(object):
         """
         endpoint = self.base_url
         data = parse.urlencode({
-            'api_key': format(self.api_key),
-            'format': 'json',
-            # responseTimes - optional (defines if the response time data of each
-            # monitor will be returned. Should be set to 1 for getting them.
-            # Default is 0)
-            'response_times': format(response_times),
-            # logs - optional (defines if the logs of each monitor will be
-            # returned. Should be set to 1 for getting the logs. Default is 0)
-            'logs': format(logs),
-            # customUptimeRatio - optional (defines the number of days to calculate
-            # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
-            # uptime ratios for those periods)
-            'custom_uptime_ratios': format(uptime_ratio)
-        }).encode('utf-8')
+                'api_key': format(self.api_key),
+                'format': 'json',
+                # responseTimes - optional (defines if the response time data of each
+                # monitor will be returned. Should be set to 1 for getting them.
+                # Default is 0)
+                'response_times': format(response_times),
+                # logs - optional (defines if the logs of each monitor will be
+                # returned. Should be set to 1 for getting the logs. Default is 0)
+                'logs': format(logs),
+                # customUptimeRatio - optional (defines the number of days to calculate
+                # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
+                # uptime ratios for those periods)
+                'custom_uptime_ratios': format(uptime_ratio)
+            }).encode('utf-8')
 
         url = request.Request(
             url=endpoint,
@@ -193,13 +193,13 @@ class Monitor(object):
                 cachet_url=website_config['cachet_url'],
             )
 
-        if 'component_id' in website_config:
+        if website_config.get('component_id'):
             self.cachet.update_component(
                 website_config['component_id'],
                 int(monitor.get('status'))
             )
 
-        if 'metric_id' in website_config:
+        if website_config.get('metric_id'):
             self.sync_metric(monitor, self.cachet)
 
     def sync_metric(self, monitor, cachet):
@@ -329,11 +329,11 @@ def parse_config(config_file):
                 })
             if 'MetricId' in config[element]:
                 monitor_dict[element_int].update({
-                    'component_id': config[element]['MetricId'],
+                    'metric_id': config[element].get('MetricId'),
                 })
             if 'ComponentId' in config[element]:
                 monitor_dict[element_int].update({
-                    'metric_id': config[element]['ComponentId'],
+                    'component_id': config[element].get('ComponentId'),
                 })
 
     cachet = CachetHq(


### PR DESCRIPTION
Updated ReadMe
Changed monitor identifiers (not per URL because these are not unique and gave issues if monitors had the same url) is now per UptimeRobot ID. (Get list of ids from UptimeRobot via --printIds)
Changed MetrixId to be optional
Changed ComponentId to be optional
Added global cachet config (per monitor cachet still works)
Updated logging
Fixed typo's
Changed MetrixId to pull stats from UptimeRobot (see 7d6a3985)

I reused allot of what @vitorbaptista already had added some of my own edits and updates to files.
Skipped the Docker integration for example.

/cc @vitorbaptista